### PR TITLE
Handle WebDriver timeouts

### DIFF
--- a/modules/wd/src/main/kotlin/info/vividcode/wd/Timeouts.kt
+++ b/modules/wd/src/main/kotlin/info/vividcode/wd/Timeouts.kt
@@ -1,0 +1,3 @@
+package info.vividcode.wd
+
+data class Timeouts(val scriptTimeoutInMs: Int, val pageLoadTimeoutInMs: Int, val implicitTimeoutInMs: Int)

--- a/modules/wd/src/main/kotlin/info/vividcode/wd/WebDriverCommand.kt
+++ b/modules/wd/src/main/kotlin/info/vividcode/wd/WebDriverCommand.kt
@@ -12,6 +12,9 @@ interface WebDriverCommand {
         SessionCommand
     data class SetWindowRect(override val session: WebDriverSession, val rect: Rect) :
         SessionCommand
+
+    data class SetTimeouts(override val session: WebDriverSession, val timeouts: Timeouts) : SessionCommand
+
     data class Go(override val session: WebDriverSession, val url: String) :
         SessionCommand
     data class ExecuteAsyncScript(override val session: WebDriverSession, val script: Script) :

--- a/modules/wd/src/main/kotlin/info/vividcode/wd/WebDriverCommandExecutor.kt
+++ b/modules/wd/src/main/kotlin/info/vividcode/wd/WebDriverCommandExecutor.kt
@@ -2,7 +2,7 @@ package info.vividcode.wd
 
 interface WebDriverCommandExecutor :
     NewSessionCommandExecutor, DeleteSessionCommandExecutor,
-    SetWindowRectExecutor,
+    SetWindowRectExecutor, SetTimeoutsExecutor,
     GoCommandExecutor, ExecuteScriptCommandExecutor,
     TakeScreenshotCommandExecutor, TakeElementScreenshotCommandExecutor,
     FindElementCommandExecutor
@@ -22,6 +22,7 @@ interface DeleteSessionCommandExecutor {
 }
 
 interface SetWindowRectExecutor { fun WebDriverCommand.SetWindowRect.execute() }
+interface SetTimeoutsExecutor { fun WebDriverCommand.SetTimeouts.execute() }
 interface GoCommandExecutor { fun WebDriverCommand.Go.execute() }
 interface ExecuteScriptCommandExecutor { fun WebDriverCommand.ExecuteAsyncScript.execute(): ScriptResult }
 interface TakeScreenshotCommandExecutor { fun WebDriverCommand.TakeScreenshot.execute(): ByteArray }

--- a/modules/wd/src/main/kotlin/info/vividcode/wd/WebDriverError.kt
+++ b/modules/wd/src/main/kotlin/info/vividcode/wd/WebDriverError.kt
@@ -1,0 +1,8 @@
+package info.vividcode.wd
+
+/**
+ * See : [https://www.w3.org/TR/webdriver/#dfn-error-code](https://www.w3.org/TR/webdriver/#dfn-error-code)
+ */
+sealed class WebDriverError : RuntimeException() {
+    class ScriptTimeout : WebDriverError()
+}

--- a/modules/wd/src/main/kotlin/info/vividcode/wd/http/implementation/OkHttpWebDriverCommandExecutor.kt
+++ b/modules/wd/src/main/kotlin/info/vividcode/wd/http/implementation/OkHttpWebDriverCommandExecutor.kt
@@ -50,6 +50,18 @@ open class OkHttpWebDriverCommandExecutor(
             )
         ) {}
 
+    override fun WebDriverCommand.SetTimeouts.execute() =
+            dispatcher.dispatch(
+                    WebDriverCommandHttpRequest(
+                            "POST", "/session/$sessionPathSegment/timeouts",
+                            JsonObject(mapOf(
+                                    "script" to timeouts.scriptTimeoutInMs,
+                                    "pageLoad" to timeouts.pageLoadTimeoutInMs,
+                                    "implicit" to timeouts.implicitTimeoutInMs
+                            )).toJsonString()
+                    )
+            ) {}
+
     override fun WebDriverCommand.Go.execute() =
         dispatcher.dispatch(
             WebDriverCommandHttpRequest(


### PR DESCRIPTION
In order to avoid session recreation on timeout.

# Waiting time for health check

It's checked by using test code of pull request #9.

## Before change

> OK (WebDriver remote ends: 2 / 2)  elapsed : 35 s

## After change

> OK (WebDriver remote ends: 2 / 2)  elapsed : 18 s