### PR TITLE
Update Kotlin (version 1.2.70)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ buildscript {
 
 plugins {
     application
-    kotlin("jvm") version "1.2.41"
+    kotlin("jvm") version "1.2.70"
 }
 apply { plugin("jacoco") }
 


### PR DESCRIPTION
* Release note : https://blog.jetbrains.com/kotlin/2018/09/kotlin-1-2-70-is-out/