### PR TITLE
Add `OriginAccessControl` feature (add `Vary` header field to HTTP response)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -48,6 +48,7 @@ dependencies {
     testRuntime("org.junit.jupiter:junit-jupiter-engine:$junitJupiterVersion")
 
     testImplementation("com.squareup.okhttp3:mockwebserver:$okHttpVersion")
+    testImplementation("io.ktor:ktor-server-test-host:$ktorVersion")
 }
 
 tasks.withType<KotlinCompile> {

--- a/src/main/kotlin/info/vividcode/wdip/Server.kt
+++ b/src/main/kotlin/info/vividcode/wdip/Server.kt
@@ -5,14 +5,15 @@ import info.vividcode.wdip.application.WdImageProcessingExecutor
 import info.vividcode.wdip.application.WebDriverConnectionManager
 import info.vividcode.wdip.ktor.SignatureVerifyingInterceptor
 import info.vividcode.wdip.ktor.WdImageProcessingInterceptor
+import info.vividcode.wdip.ktor.features.OriginAccessControl
 import info.vividcode.wdip.ktor.getAndHead
 import info.vividcode.wdip.ktor.routeGetAndHead
 import io.ktor.application.ApplicationCall
 import io.ktor.application.ApplicationCallPipeline
 import io.ktor.application.call
+import io.ktor.application.install
 import io.ktor.http.HttpStatusCode
 import io.ktor.pipeline.PipelineInterceptor
-import io.ktor.request.header
 import io.ktor.response.header
 import io.ktor.response.respond
 import io.ktor.routing.routing
@@ -77,12 +78,8 @@ fun startServer() {
             call.response.header("X-Content-Type-Options", "nosniff")
         }
 
-        intercept(ApplicationCallPipeline.Call) {
-            call.request.header("Origin")?.let { origin ->
-                if (config.accessControlAllowOrigins.contains(origin)) {
-                    call.response.header("Access-Control-Allow-Origin", origin)
-                }
-            }
+        install(OriginAccessControl) {
+            accessControlAllowOrigins.addAll(config.accessControlAllowOrigins)
         }
 
         routing {

--- a/src/main/kotlin/info/vividcode/wdip/ktor/features/OriginAccessControl.kt
+++ b/src/main/kotlin/info/vividcode/wdip/ktor/features/OriginAccessControl.kt
@@ -1,0 +1,51 @@
+package info.vividcode.wdip.ktor.features
+
+import io.ktor.application.ApplicationCallPipeline
+import io.ktor.application.ApplicationFeature
+import io.ktor.application.call
+import io.ktor.features.CORS
+import io.ktor.request.header
+import io.ktor.response.header
+import io.ktor.util.AttributeKey
+
+/**
+ * This feature provides a mechanism that checks `Origin` header and respond necessary headers.
+ *
+ * Headers added to response are following:
+ *
+ * * `Access-Control-Allow-Origin` header : added if the `Origin` header value of request is contained in
+ *   [Configuration.accessControlAllowOrigins], or not added otherwise.
+ * * `Vary: Origin` header
+ *
+ * This feature may be able to be replaced with [CORS] feature.
+ */
+class OriginAccessControl(private val accessControlAllowOrigins: Set<String>) {
+
+    /**
+     * Configuration of [OriginAccessControl] feature.
+     */
+    class Configuration {
+        val accessControlAllowOrigins = mutableSetOf<String>()
+    }
+
+    companion object Feature : ApplicationFeature<ApplicationCallPipeline, Configuration, OriginAccessControl> {
+        override val key = AttributeKey<OriginAccessControl>("OriginAccessControl")
+
+        override fun install(pipeline: ApplicationCallPipeline, configure: Configuration.() -> Unit): OriginAccessControl {
+            val configuration = Configuration().apply(configure)
+            val originHeaders = OriginAccessControl(configuration.accessControlAllowOrigins)
+
+            pipeline.intercept(ApplicationCallPipeline.Call) {
+                call.response.header("Vary", "Origin")
+                call.request.header("Origin")?.let { origin ->
+                    if (originHeaders.accessControlAllowOrigins.contains(origin)) {
+                        call.response.header("Access-Control-Allow-Origin", origin)
+                    }
+                }
+            }
+
+            return originHeaders
+        }
+    }
+
+}

--- a/src/test/kotlin/info/vividcode/wdip/ktor/features/OriginAccessControlTest.kt
+++ b/src/test/kotlin/info/vividcode/wdip/ktor/features/OriginAccessControlTest.kt
@@ -1,0 +1,89 @@
+package info.vividcode.wdip.ktor.features
+
+import io.ktor.application.install
+import io.ktor.http.Headers
+import io.ktor.server.testing.withTestApplication
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+
+internal class OriginAccessControlTest {
+
+    @Test
+    internal fun standard() = withTestApplication {
+        application.install(OriginAccessControl) {
+            accessControlAllowOrigins.add("test.com")
+            accessControlAllowOrigins.add("b.test.org")
+        }
+
+        // No origin header
+        handleRequest {
+        }.let { call ->
+            Assertions.assertEquals(
+                    Headers.build {
+                        set("Vary", "Origin")
+                    },
+                    call.response.headers.allValues()
+            )
+        }
+
+        // Not allowed origins
+        listOf("test.org", "other.info").forEach { testOrigin ->
+            handleRequest {
+                addHeader("Origin", testOrigin)
+            }.let { call ->
+                Assertions.assertEquals(
+                        Headers.build {
+                            set("Vary", "Origin")
+                        },
+                        call.response.headers.allValues()
+                )
+            }
+        }
+
+        // Allowed origins
+        listOf("test.com", "b.test.org").forEach { testOrigin ->
+            handleRequest {
+                addHeader("Origin", testOrigin)
+            }.let { call ->
+                Assertions.assertEquals(
+                        Headers.build {
+                            set("Vary", "Origin")
+                            set("Access-Control-Allow-Origin", testOrigin)
+                        },
+                        call.response.headers.allValues()
+                )
+            }
+        }
+    }
+
+    @Test
+    internal fun withoutConfiguration() = withTestApplication {
+        application.install(OriginAccessControl)
+
+        // No origin header
+        handleRequest {
+        }.let { call ->
+            Assertions.assertEquals(
+                    Headers.build {
+                        set("Vary", "Origin")
+                    },
+                    call.response.headers.allValues()
+            )
+        }
+
+        // Not allowed origins
+        listOf("test.org", "other.info").forEach { testOrigin ->
+            handleRequest {
+                addHeader("Origin", testOrigin)
+            }.let { call ->
+                Assertions.assertEquals(
+                        Headers.build {
+                            set("Vary", "Origin")
+                        },
+                        call.response.headers.allValues()
+                )
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
Because response headers will vary by `Origin` header field of request.

See : https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS