### PR TITLE
Migrate javax.json to jakarta.json

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -32,7 +32,7 @@ dependencies {
     implementation("io.ktor:ktor-server-core:$ktorVersion")
     implementation("io.ktor:ktor-server-netty:$ktorVersion")
 
-    implementation("org.glassfish:javax.json:1.1.4")
+    implementation("org.glassfish:jakarta.json:1.1.5")
 
     // JUnit Jupiter API and TestEngine implementation
     testCompile("org.junit.jupiter:junit-jupiter-api:$junitJupiterVersion")

--- a/modules/wd-okhttp/build.gradle.kts
+++ b/modules/wd-okhttp/build.gradle.kts
@@ -22,7 +22,7 @@ dependencies {
     testCompileOnly("org.junit.jupiter:junit-jupiter-api:$junitJupiterVersion")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:$junitJupiterVersion")
 
-    testRuntimeOnly("org.glassfish:javax.json:1.1.4")
+    testRuntimeOnly("org.glassfish:jakarta.json:1.1.5")
 
     testImplementation(project(":modules:test-utils"))
 

--- a/modules/wd-test-server/build.gradle.kts
+++ b/modules/wd-test-server/build.gradle.kts
@@ -10,7 +10,7 @@ dependencies {
 
     implementation(kotlin("stdlib-jdk8"))
 
-    implementation("org.glassfish:javax.json:1.1.4")
+    implementation("org.glassfish:jakarta.json:1.1.5")
     implementation("com.squareup.okhttp3:mockwebserver:$okHttpVersion")
 }
 

--- a/modules/wd/build.gradle.kts
+++ b/modules/wd/build.gradle.kts
@@ -15,13 +15,13 @@ dependencies {
     val junitJupiterVersion = "5.2.0"
 
     implementation(kotlin("stdlib-jdk8"))
-    api("javax.json:javax.json-api:1.1.4")
+    api("jakarta.json:jakarta.json-api:1.1.5")
 
     // JUnit Jupiter API and TestEngine implementation
     testCompileOnly("org.junit.jupiter:junit-jupiter-api:$junitJupiterVersion")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:$junitJupiterVersion")
 
-    testRuntimeOnly("org.glassfish:javax.json:1.1.4")
+    testRuntimeOnly("org.glassfish:jakarta.json:1.1.5")
 
     testImplementation(project(":modules:test-utils"))
     testImplementation(project(":modules:wd-okhttp"))

--- a/modules/wdip-usecase/build.gradle.kts
+++ b/modules/wdip-usecase/build.gradle.kts
@@ -28,7 +28,7 @@ dependencies {
 
     implementation(kotlin("stdlib-jdk8"))
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:$kotlinxCoroutinesVersion")
-    runtimeOnly("org.glassfish:javax.json:1.1.4")
+    runtimeOnly("org.glassfish:jakarta.json:1.1.5")
 
     // JUnit Jupiter API and TestEngine implementation
     testCompileOnly("org.junit.jupiter:junit-jupiter-api:$junitJupiterVersion")


### PR DESCRIPTION
See : [Java EE 技術から EE4J (Jakarta EE) 技術に移行する](https://vividcode.hatenablog.com/entry/java/java-ee-to-ee4j)

https://github.com/nobuoka/wd-image-processor/projects/1#card-18302129